### PR TITLE
Investigate iOS UI display issues on iPhone 11

### DIFF
--- a/iOS_Display_Issues_Analysis.md
+++ b/iOS_Display_Issues_Analysis.md
@@ -1,0 +1,177 @@
+# iOS（iPhone11）表示問題の原因分析
+
+## 問題の概要
+
+iOS（iPhone11）で表示した際に以下の問題が発生しています：
+
+1. **サイドバーが上で見切れる問題**
+   - モバイルサイドバーが画面の上部で見切れてしまい、タップが困難
+   
+2. **タブバーが下に浮く問題**
+   - 下部のタブバーが少し上に浮いており、下に隙間が生じている
+
+## 原因の特定
+
+### 1. サイドバーが見切れる問題
+
+#### 原因：モバイルサイドバーの位置指定とz-indexの問題
+
+**該当コード：**
+```jsx
+// src/App.jsx (lines 568-600)
+{/* Mobile Sidebar Overlay */}
+{isMobile && (
+  <div className={`fixed inset-0 z-50 flex transition-all duration-150 ease-out ${
+    sidebarOpen ? 'opacity-100 visible' : 'opacity-0 invisible'
+  }`}>
+    <div 
+      className="fixed inset-0 bg-background/80 backdrop-blur-sm transition-opacity duration-150 ease-out"
+      onClick={(e) => {
+        e.stopPropagation();
+        setSidebarOpen(false);
+      }}
+      onTouchStart={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setSidebarOpen(false);
+      }}
+    />
+    <div 
+      className={`relative w-[85vw] max-w-sm sm:w-80 bg-card border-r border-border h-full transform transition-transform duration-150 ease-out ${
+        sidebarOpen ? 'translate-x-0' : '-translate-x-full'
+      }`}
+      onClick={(e) => e.stopPropagation()}
+      onTouchStart={(e) => e.stopPropagation()}
+    >
+```
+
+**問題点：**
+- `fixed inset-0` により画面全体を覆うが、iOSのステータスバーやノッチ領域を考慮していない
+- `h-full` により画面の高さ全体を使用しているが、iOSの安全領域（Safe Area）を無視している
+- z-indexは適切に設定されているが、位置指定が不適切
+
+### 2. タブバーが下に浮く問題
+
+#### 原因：iOS Safe Area Insetsの不適切な適用
+
+**該当コード：**
+```jsx
+// src/components/MobileNav.jsx (lines 50-52)
+className={`mobile-nav-container fixed bottom-0 left-0 right-0 border-t border-gray-200 dark:border-gray-700 z-50 ios-bottom-safe transform transition-transform duration-300 ease-in-out shadow-lg ${
+  isInputFocused ? 'translate-y-full' : 'translate-y-0'
+}`}
+```
+
+**CSS定義：**
+```css
+/* src/index.css (lines 575-576) */
+.ios-bottom-safe {
+  padding-bottom: max(env(safe-area-inset-bottom), 12px);
+}
+```
+
+**問題点：**
+- `ios-bottom-safe` クラスは適用されているが、`padding-bottom` のみで対応
+- iOSのSafe Area Insetsが適切に反映されていない可能性
+- `env(safe-area-inset-bottom)` の値が期待通りに動作していない
+
+## 技術的な詳細
+
+### 1. Viewport設定
+
+**現在の設定：**
+```html
+<!-- index.html (line 6) -->
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+```
+
+**評価：**
+- `viewport-fit=cover` は適切に設定されている
+- iOSのノッチ領域をカバーする設定になっている
+
+### 2. Safe Area Insetsの使用状況
+
+**現在の実装：**
+- `env(safe-area-inset-bottom)` のみ使用
+- `env(safe-area-inset-top)` が使用されていない
+- サイドバーでSafe Area Insetsが考慮されていない
+
+### 3. モバイル判定ロジック
+
+**現在の実装：**
+```jsx
+// src/App.jsx (lines 75-82)
+useEffect(() => {
+  const checkMobile = () => {
+    setIsMobile(window.innerWidth < 768);
+  };
+  
+  checkMobile();
+  window.addEventListener('resize', checkMobile);
+  
+  return () => window.removeEventListener('resize', checkMobile);
+}, []);
+```
+
+**評価：**
+- 画面幅のみでモバイル判定を行っている
+- iOSのデバイス特性を考慮していない
+
+## 修正が必要な箇所
+
+### 1. サイドバーの修正
+
+**推奨修正：**
+- `fixed inset-0` を `fixed top-0 left-0 right-0 bottom-0` に変更
+- `env(safe-area-inset-top)` を考慮したpadding-topの追加
+- サイドバーの高さを `calc(100vh - env(safe-area-inset-top))` に変更
+
+### 2. タブバーの修正
+
+**推奨修正：**
+- `env(safe-area-inset-bottom)` の値を確認
+- `bottom: env(safe-area-inset-bottom)` の追加
+- 必要に応じて `padding-bottom` の調整
+
+### 3. CSSの追加
+
+**推奨追加：**
+```css
+/* iOS Safe Area対応のための追加CSS */
+.ios-safe-top {
+  padding-top: env(safe-area-inset-top);
+}
+
+.ios-safe-bottom {
+  padding-bottom: env(safe-area-inset-bottom);
+}
+
+.mobile-sidebar {
+  height: calc(100vh - env(safe-area-inset-top));
+  top: env(safe-area-inset-top);
+}
+```
+
+## 検証方法
+
+### 1. デバイステスト
+- iPhone11（iOS 16+）での実機テスト
+- Safariでの表示確認
+- 横画面・縦画面の両方でテスト
+
+### 2. 開発者ツール
+- Safari Developer ToolsでのSafe Area Insets値の確認
+- `env(safe-area-inset-top)` と `env(safe-area-inset-bottom)` の実際の値を確認
+
+### 3. ブラウザ互換性
+- iOS Safariでの動作確認
+- 他のモバイルブラウザでの動作確認
+
+## 結論
+
+現在の実装では、iOSのSafe Area Insetsが適切に考慮されていないことが主な原因です。特に：
+
+1. **サイドバー問題**：`env(safe-area-inset-top)` が考慮されていない
+2. **タブバー問題**：`env(safe-area-inset-bottom)` の適用方法が不適切
+
+これらの問題は、iOSのノッチやホームインジケーター領域を適切に回避するためのSafe Area Insetsの実装を改善することで解決できます。


### PR DESCRIPTION
Add `iOS_Display_Issues_Analysis.md` to document the causes of sidebar clipping and tab bar floating on iPhone 11.

The document identifies that the sidebar clipping and tab bar floating on iPhone 11 are primarily caused by the improper handling of iOS Safe Area Insets (top and bottom) within the application's CSS and component layouts.

---
<a href="https://cursor.com/background-agent?bcId=bc-cfeb0263-e49d-46f0-b003-fe8c79c29572">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cfeb0263-e49d-46f0-b003-fe8c79c29572">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

